### PR TITLE
Fix buffer allocation in Read_File

### DIFF
--- a/schichor_program/Core/Src/File_Handling_RTOS.c
+++ b/schichor_program/Core/Src/File_Handling_RTOS.c
@@ -214,8 +214,9 @@ FRESULT Read_File (char *name)
 		/* Read data from the file
 		* see the function details for the arguments */
 
-		char *buffer = pvPortMalloc(sizeof(f_size(&fil)));
-		fresult = f_read (&fil, buffer, f_size(&fil), &br);
+               char *buffer = pvPortMalloc(f_size(&fil) + 1);
+               fresult = f_read (&fil, buffer, f_size(&fil), &br);
+               buffer[f_size(&fil)] = '\0';
 		if (fresult != FR_OK)
 		{
 			char *buf = pvPortMalloc(100*sizeof(char));


### PR DESCRIPTION
## Summary
- avoid using sizeof on value when allocating file buffer
- ensure buffer is NUL terminated

## Testing
- `gcc -c schichor_program/Core/Src/File_Handling_RTOS.c -Ischichor_program/Core/Inc -o /tmp/test.o` *(fails: fatfs.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846b65cf3f48327b7d1408e0acdd47b