### PR TITLE
Add simple unit test for FONTS_GetStringSize

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,12 @@
+CC ?= gcc
+CFLAGS += -I../schichor_program/Core/Inc -I.
+
+all: test_fonts
+
+# Single source compilation since fonts.c is included in test_fonts.c
+
+test_fonts: test_fonts.c stm32f4xx_hal.h
+	$(CC) $(CFLAGS) $< -o $@
+
+clean:
+	rm -f test_fonts

--- a/tests/stm32f4xx_hal.h
+++ b/tests/stm32f4xx_hal.h
@@ -1,0 +1,4 @@
+#ifndef STM32F4XX_HAL_H
+#define STM32F4XX_HAL_H
+#include <stdint.h>
+#endif

--- a/tests/test_fonts.c
+++ b/tests/test_fonts.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <string.h>
+
+#include "fonts.h"
+#include "../schichor_program/Core/Src/fonts.c"
+
+int main(void) {
+    char *str = "Hello";
+    FontDef_t Font = { .FontWidth = 5, .FontHeight = 7, .data = NULL };
+    FONTS_SIZE_t Size;
+    char *ret = FONTS_GetStringSize(str, &Size, &Font);
+    assert(ret == str);
+    assert(Size.Length == strlen(str) * Font.FontWidth);
+    assert(Size.Height == Font.FontHeight);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a stub `stm32f4xx_hal.h` with minimal definitions for host build
- add `test_fonts.c` to exercise `FONTS_GetStringSize`
- provide a small Makefile to build the test on a host compiler

## Testing
- `make clean && make` in `tests`
- `./test_fonts`


------
https://chatgpt.com/codex/tasks/task_e_6846b74d91a48327ac47a60bda3b750b